### PR TITLE
Removed macro processing and added support for hugo shortcodes 

### DIFF
--- a/test/md/block-macro.md.json
+++ b/test/md/block-macro.md.json
@@ -1,8 +1,7 @@
 {
   "title": "Block Macro Issue",
   "body": {
-    "content": [
-      {
+    "content": [{
         "endIndex": 1,
         "sectionBreak": {
           "sectionStyle": {
@@ -16,16 +15,14 @@
         "startIndex": 1,
         "endIndex": 451,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1,
-              "endIndex": 451,
-              "textRun": {
-                "content": "In order to better serve client needs, {system-name } has streamlined the concepts and efforts of quality reporting participation, in order to serve all interested entities. If, as a standard, a business would like to track ongoing quality of care initiatives, or even participate in sponsored quality programs, {system-name } systems now offer a plethora of quantifiable and reportable measures, designed to track and improve overall care delivery.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1,
+            "endIndex": 451,
+            "textRun": {
+              "content": "In order to better serve client needs, {{% system-name %}} has streamlined the concepts and efforts of quality reporting participation, in order to serve all interested entities. If, as a standard, a business would like to track ongoing quality of care initiatives, or even participate in sponsored quality programs, {{% system-name %}} systems now offer a plethora of quantifiable and reportable measures, designed to track and improve overall care delivery.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -89,8 +86,7 @@
         "startIndex": 451,
         "endIndex": 781,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 451,
               "endIndex": 742,
               "textRun": {
@@ -194,16 +190,14 @@
         "startIndex": 781,
         "endIndex": 818,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 781,
-              "endIndex": 818,
-              "textRun": {
-                "content": "Enroll via Quality Reporting Portlet\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 781,
+            "endIndex": 818,
+            "textRun": {
+              "content": "Enroll via Quality Reporting Portlet\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_2",
             "direction": "LEFT_TO_RIGHT",
@@ -270,12 +264,11 @@
         "startIndex": 818,
         "endIndex": 1124,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 818,
               "endIndex": 908,
               "textRun": {
-                "content": "Navigate to the {syslink \"Quick View\" \"func=omniscope\"} from the sidemenu, and locate the ",
+                "content": "Navigate to the {{% syslink \"Quick View\" \"func=omniscope\" %}} from the sidemenu, and locate the ",
                 "textStyle": {}
               }
             },
@@ -330,7 +323,7 @@
               "startIndex": 935,
               "endIndex": 1001,
               "textRun": {
-                "content": "{tip }\u000bIf the Quality Reporting portlet is not enabled, click the ",
+                "content": "{{% tip %}}\u000bIf the Quality Reporting portlet is not enabled, click the ",
                 "textStyle": {}
               }
             },
@@ -400,7 +393,7 @@
               "startIndex": 1116,
               "endIndex": 1124,
               "textRun": {
-                "content": "\u000b{/tip}\n",
+                "content": "\u000b{{% /tip %}}\n",
                 "textStyle": {}
               }
             }
@@ -480,12 +473,11 @@
         "startIndex": 1124,
         "endIndex": 1555,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1124,
               "endIndex": 1297,
               "textRun": {
-                "content": "Click the {syslink \"Enroll\" \"f=layout&module=MIPS&name=Advanced+Measure+Enrollment&user_id=50&redirect=f%3Domniscope&tabmodule=+\"} hyperlink to begin the enrollment process.",
+                "content": "Click the {{% syslink \"Enroll\" \"f=layout&module=MIPS&name=Advanced+Measure+Enrollment&user_id=50&redirect=f%3Domniscope&tabmodule=+\" %}} hyperlink to begin the enrollment process.",
                 "textStyle": {}
               }
             },
@@ -580,7 +572,7 @@
               "startIndex": 1303,
               "endIndex": 1313,
               "textRun": {
-                "content": "{warning }",
+                "content": "{{% warning %}}",
                 "textStyle": {}
               }
             },
@@ -712,7 +704,7 @@
               "startIndex": 1544,
               "endIndex": 1555,
               "textRun": {
-                "content": "{/warning}\n",
+                "content": "{{% /warning %}}\n",
                 "textStyle": {}
               }
             }
@@ -792,8 +784,7 @@
         "startIndex": 1555,
         "endIndex": 1791,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1555,
               "endIndex": 1585,
               "textRun": {
@@ -1000,8 +991,7 @@
         "startIndex": 1791,
         "endIndex": 1964,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1791,
               "endIndex": 1883,
               "textRun": {
@@ -1190,8 +1180,7 @@
         "startIndex": 1964,
         "endIndex": 2810,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1964,
               "endIndex": 1979,
               "textRun": {
@@ -1327,7 +1316,7 @@
               "startIndex": 2158,
               "endIndex": 2165,
               "textRun": {
-                "content": "{info }",
+                "content": "{{% info %}}",
                 "textStyle": {}
               }
             },
@@ -1429,7 +1418,7 @@
               "startIndex": 2284,
               "endIndex": 2291,
               "textRun": {
-                "content": "{/info}",
+                "content": "{{% /info %}}",
                 "textStyle": {}
               }
             },
@@ -1466,7 +1455,7 @@
               "startIndex": 2292,
               "endIndex": 2302,
               "textRun": {
-                "content": "{warning }",
+                "content": "{{% warning %}}",
                 "textStyle": {}
               }
             },
@@ -1542,7 +1531,7 @@
               "startIndex": 2797,
               "endIndex": 2807,
               "textRun": {
-                "content": "{/warning}",
+                "content": "{{% /warning %}}",
                 "textStyle": {}
               }
             },
@@ -1651,8 +1640,7 @@
         "startIndex": 2810,
         "endIndex": 3025,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 2810,
               "endIndex": 2868,
               "textRun": {
@@ -1769,7 +1757,7 @@
               "startIndex": 2886,
               "endIndex": 2893,
               "textRun": {
-                "content": "{info }",
+                "content": "{{% info %}}",
                 "textStyle": {}
               }
             },
@@ -1901,7 +1889,7 @@
               "startIndex": 3017,
               "endIndex": 3025,
               "textRun": {
-                "content": "{/info}\n",
+                "content": "{{% /info %}}\n",
                 "textStyle": {}
               }
             }
@@ -1981,16 +1969,14 @@
         "startIndex": 6002,
         "endIndex": 6003,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 6002,
-              "endIndex": 6003,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 6002,
+            "endIndex": 6003,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2054,16 +2040,14 @@
         "startIndex": 6003,
         "endIndex": 6004,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 6003,
-              "endIndex": 6004,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 6003,
+            "endIndex": 6004,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2127,8 +2111,7 @@
         "startIndex": 6004,
         "endIndex": 6226,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 6004,
               "endIndex": 6005,
               "inlineObjectElement": {
@@ -2247,8 +2230,7 @@
     }
   },
   "namedStyles": {
-    "styles": [
-      {
+    "styles": [{
         "namedStyleType": "NORMAL_TEXT",
         "textStyle": {},
         "paragraphStyle": {
@@ -2852,8 +2834,7 @@
   "lists": {
     "kix.list.1": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -3173,8 +3154,7 @@
     },
     "kix.list.2": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {

--- a/test/md/confluence.md.json
+++ b/test/md/confluence.md.json
@@ -1,8 +1,7 @@
 {
   "title": "Confluence to Google Docs Conversion Notes",
   "body": {
-    "content": [
-      {
+    "content": [{
         "endIndex": 1,
         "sectionBreak": {
           "sectionStyle": {
@@ -15,16 +14,14 @@
         "startIndex": 1,
         "endIndex": 44,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1,
-              "endIndex": 44,
-              "textRun": {
-                "content": "Confluence to Google Docs Conversion Notes\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1,
+            "endIndex": 44,
+            "textRun": {
+              "content": "Confluence to Google Docs Conversion Notes\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.77510dqpcwl",
             "namedStyleType": "HEADING_1",
@@ -36,16 +33,14 @@
         "startIndex": 44,
         "endIndex": 49,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 44,
-              "endIndex": 49,
-              "textRun": {
-                "content": "Goal\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 44,
+            "endIndex": 49,
+            "textRun": {
+              "content": "Goal\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.10c0ntqm6mev",
             "namedStyleType": "HEADING_2",
@@ -57,16 +52,14 @@
         "startIndex": 49,
         "endIndex": 154,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 49,
-              "endIndex": 154,
-              "textRun": {
-                "content": "Convert Confluence Documents in to Google Documents for the purpose of using WikiGDrive to publish them.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 49,
+            "endIndex": 154,
+            "textRun": {
+              "content": "Convert Confluence Documents in to Google Documents for the purpose of using WikiGDrive to publish them.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -77,16 +70,14 @@
         "startIndex": 154,
         "endIndex": 155,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 154,
-              "endIndex": 155,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 154,
+            "endIndex": 155,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -97,16 +88,14 @@
         "startIndex": 155,
         "endIndex": 164,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 155,
-              "endIndex": 164,
-              "textRun": {
-                "content": "Delivery\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 155,
+            "endIndex": 164,
+            "textRun": {
+              "content": "Delivery\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.i96xic41327t",
             "namedStyleType": "HEADING_2",
@@ -118,16 +107,14 @@
         "startIndex": 164,
         "endIndex": 233,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 164,
-              "endIndex": 233,
-              "textRun": {
-                "content": "A new github repo with a node.js script specific to this conversion.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 164,
+            "endIndex": 233,
+            "textRun": {
+              "content": "A new github repo with a node.js script specific to this conversion.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -138,16 +125,14 @@
         "startIndex": 233,
         "endIndex": 252,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 233,
-              "endIndex": 252,
-              "textRun": {
-                "content": "High level Process\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 233,
+            "endIndex": 252,
+            "textRun": {
+              "content": "High level Process\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.wrw8sf3g3pc3",
             "namedStyleType": "HEADING_2",
@@ -159,16 +144,14 @@
         "startIndex": 252,
         "endIndex": 300,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 252,
-              "endIndex": 300,
-              "textRun": {
-                "content": "Scan all of the documents in a Confluence Space\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 252,
+            "endIndex": 300,
+            "textRun": {
+              "content": "Scan all of the documents in a Confluence Space\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -194,16 +177,14 @@
         "startIndex": 300,
         "endIndex": 430,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 300,
-              "endIndex": 430,
-              "textRun": {
-                "content": "Make google documents in a shared drive (two passes will be required so links between documents can be known as content is added.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 300,
+            "endIndex": 430,
+            "textRun": {
+              "content": "Make google documents in a shared drive (two passes will be required so links between documents can be known as content is added.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -229,16 +210,14 @@
         "startIndex": 430,
         "endIndex": 505,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 430,
-              "endIndex": 505,
-              "textRun": {
-                "content": "Import Confluence \"Attachments\" to Google Drive so they can be referenced.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 430,
+            "endIndex": 505,
+            "textRun": {
+              "content": "Import Confluence \"Attachments\" to Google Drive so they can be referenced.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -264,16 +243,14 @@
         "startIndex": 505,
         "endIndex": 523,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 505,
-              "endIndex": 523,
-              "textRun": {
-                "content": "For each document\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 505,
+            "endIndex": 523,
+            "textRun": {
+              "content": "For each document\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -299,16 +276,14 @@
         "startIndex": 523,
         "endIndex": 581,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 523,
-              "endIndex": 581,
-              "textRun": {
-                "content": "Import content from Confluence Page into Google Documents\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 523,
+            "endIndex": 581,
+            "textRun": {
+              "content": "Import content from Confluence Page into Google Documents\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -335,16 +310,14 @@
         "startIndex": 581,
         "endIndex": 608,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 581,
-              "endIndex": 608,
-              "textRun": {
-                "content": "Heading should be headings\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 581,
+            "endIndex": 608,
+            "textRun": {
+              "content": "Heading should be headings\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -371,16 +344,14 @@
         "startIndex": 608,
         "endIndex": 640,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 608,
-              "endIndex": 640,
-              "textRun": {
-                "content": "Paragraphs should be paragraphs\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 608,
+            "endIndex": 640,
+            "textRun": {
+              "content": "Paragraphs should be paragraphs\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -407,16 +378,14 @@
         "startIndex": 640,
         "endIndex": 719,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 640,
-              "endIndex": 719,
-              "textRun": {
-                "content": "Images (which are attachments in Confluence) should be embedded in google docs\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 640,
+            "endIndex": 719,
+            "textRun": {
+              "content": "Images (which are attachments in Confluence) should be embedded in google docs\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -443,12 +412,11 @@
         "startIndex": 719,
         "endIndex": 773,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 719,
               "endIndex": 772,
               "textRun": {
-                "content": "Macros can be wrapped in {curlies} and dumped as text",
+                "content": "Macros can be wrapped in {{% curlies %}} and dumped as text",
                 "textStyle": {}
               }
             },
@@ -489,8 +457,7 @@
         "startIndex": 773,
         "endIndex": 885,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 773,
               "endIndex": 793,
               "textRun": {
@@ -505,7 +472,7 @@
               "startIndex": 793,
               "endIndex": 885,
               "textRun": {
-                "content": "  \u000b{macroname propertyname=’value’ propertyname=’value’}\u000bmacro body, if exists\u000b{/macroname}\n",
+                "content": "  \u000b{{% macroname propertyname=’value’ propertyname=’value’ %}}\u000bmacro body, if exists\u000b{{% /macroname %}}\n",
                 "textStyle": {}
               }
             }
@@ -536,8 +503,7 @@
         "startIndex": 885,
         "endIndex": 963,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 885,
               "endIndex": 906,
               "textRun": {
@@ -551,7 +517,7 @@
               "startIndex": 906,
               "endIndex": 963,
               "textRun": {
-                "content": "\u000b{macroname propertyname=’value’ propertyname=’value’ /}\n",
+                "content": "\u000b{{% macroname propertyname=’value’ propertyname=’value’ /%}}\n",
                 "textStyle": {}
               }
             }
@@ -582,16 +548,14 @@
         "startIndex": 963,
         "endIndex": 992,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 963,
-              "endIndex": 992,
-              "textRun": {
-                "content": "Tables should be kept tables\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 963,
+            "endIndex": 992,
+            "textRun": {
+              "content": "Tables should be kept tables\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -618,16 +582,14 @@
         "startIndex": 992,
         "endIndex": 1056,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 992,
-              "endIndex": 1056,
-              "textRun": {
-                "content": "Embedded Video should be converted to an image with a hyperlink\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 992,
+            "endIndex": 1056,
+            "textRun": {
+              "content": "Embedded Video should be converted to an image with a hyperlink\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -654,16 +616,14 @@
         "startIndex": 1056,
         "endIndex": 1100,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1056,
-              "endIndex": 1100,
-              "textRun": {
-                "content": "Formatting is not required to be converted.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1056,
+            "endIndex": 1100,
+            "textRun": {
+              "content": "Formatting is not required to be converted.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -690,16 +650,14 @@
         "startIndex": 1100,
         "endIndex": 1101,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1100,
-              "endIndex": 1101,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1100,
+            "endIndex": 1101,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -710,16 +668,14 @@
         "startIndex": 1101,
         "endIndex": 1123,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1101,
-              "endIndex": 1123,
-              "textRun": {
-                "content": "Proposed Instructions\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1101,
+            "endIndex": 1123,
+            "textRun": {
+              "content": "Proposed Instructions\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.m98292szff3y",
             "namedStyleType": "HEADING_2",
@@ -731,16 +687,14 @@
         "startIndex": 1123,
         "endIndex": 1124,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1123,
-              "endIndex": 1124,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1123,
+            "endIndex": 1124,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -751,16 +705,14 @@
         "startIndex": 1124,
         "endIndex": 1188,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1124,
-              "endIndex": 1188,
-              "textRun": {
-                "content": "confluence2google <path to space> <path to google shared drive>\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1124,
+            "endIndex": 1188,
+            "textRun": {
+              "content": "confluence2google <path to space> <path to google shared drive>\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.x0pn817jsti8",
             "namedStyleType": "SUBTITLE",
@@ -780,16 +732,14 @@
         "startIndex": 1188,
         "endIndex": 1189,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1188,
-              "endIndex": 1189,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1188,
+            "endIndex": 1189,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -800,16 +750,14 @@
         "startIndex": 1189,
         "endIndex": 1219,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1189,
-              "endIndex": 1219,
-              "textRun": {
-                "content": "Links and Possible Approaches\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1189,
+            "endIndex": 1219,
+            "textRun": {
+              "content": "Links and Possible Approaches\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.sdx7522zhby",
             "namedStyleType": "HEADING_2",
@@ -821,16 +769,14 @@
         "startIndex": 1219,
         "endIndex": 1232,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1219,
-              "endIndex": 1232,
-              "textRun": {
-                "content": "Use REST API\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1219,
+            "endIndex": 1232,
+            "textRun": {
+              "content": "Use REST API\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -856,8 +802,7 @@
         "startIndex": 1232,
         "endIndex": 1258,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1232,
               "endIndex": 1257,
               "textRun": {
@@ -914,8 +859,7 @@
         "startIndex": 1258,
         "endIndex": 1285,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1258,
               "endIndex": 1284,
               "textRun": {
@@ -972,8 +916,7 @@
         "startIndex": 1285,
         "endIndex": 1345,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1285,
               "endIndex": 1344,
               "textRun": {
@@ -1030,8 +973,7 @@
         "startIndex": 1345,
         "endIndex": 1423,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1345,
               "endIndex": 1365,
               "textRun": {
@@ -1096,16 +1038,14 @@
         "startIndex": 1423,
         "endIndex": 1439,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1423,
-              "endIndex": 1439,
-              "textRun": {
-                "content": "Use export file\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1423,
+            "endIndex": 1439,
+            "textRun": {
+              "content": "Use export file\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1131,8 +1071,7 @@
         "startIndex": 1439,
         "endIndex": 1493,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1439,
               "endIndex": 1456,
               "textRun": {
@@ -1219,8 +1158,7 @@
         "startIndex": 1493,
         "endIndex": 1516,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1493,
               "endIndex": 1514,
               "textRun": {
@@ -1277,8 +1215,7 @@
         "startIndex": 1516,
         "endIndex": 1537,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1516,
               "endIndex": 1536,
               "textRun": {
@@ -1335,16 +1272,14 @@
         "startIndex": 1537,
         "endIndex": 1546,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1537,
-              "endIndex": 1546,
-              "textRun": {
-                "content": "Use HTML\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1537,
+            "endIndex": 1546,
+            "textRun": {
+              "content": "Use HTML\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1370,8 +1305,7 @@
         "startIndex": 1546,
         "endIndex": 1588,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1546,
               "endIndex": 1563,
               "textRun": {
@@ -1426,16 +1360,14 @@
         "startIndex": 1588,
         "endIndex": 1589,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1588,
-              "endIndex": 1589,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1588,
+            "endIndex": 1589,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1446,16 +1378,14 @@
         "startIndex": 1589,
         "endIndex": 1598,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1589,
-              "endIndex": 1598,
-              "textRun": {
-                "content": "Examples\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1589,
+            "endIndex": 1598,
+            "textRun": {
+              "content": "Examples\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.rsmqmchgeq17",
             "namedStyleType": "HEADING_2",
@@ -1467,8 +1397,7 @@
         "startIndex": 1598,
         "endIndex": 1677,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1598,
               "endIndex": 1607,
               "textRun": {
@@ -1517,8 +1446,7 @@
         "startIndex": 1677,
         "endIndex": 1743,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1677,
               "endIndex": 1688,
               "textRun": {
@@ -1567,8 +1495,7 @@
         "startIndex": 1743,
         "endIndex": 1820,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1743,
               "endIndex": 1753,
               "textRun": {
@@ -1617,8 +1544,7 @@
         "startIndex": 1820,
         "endIndex": 1886,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1820,
               "endIndex": 1831,
               "textRun": {
@@ -1667,16 +1593,14 @@
         "startIndex": 1886,
         "endIndex": 1887,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1886,
-              "endIndex": 1887,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1886,
+            "endIndex": 1887,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1718,8 +1642,7 @@
     }
   },
   "namedStyles": {
-    "styles": [
-      {
+    "styles": [{
         "namedStyleType": "NORMAL_TEXT",
         "textStyle": {
           "bold": false,
@@ -2061,8 +1984,7 @@
   "lists": {
     "kix.a79dsvt333v7": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "DECIMAL",
             "glyphFormat": "%0.",
@@ -2220,8 +2142,7 @@
     },
     "kix.ffbujqaur4f": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphSymbol": "●",
             "glyphFormat": "%0",

--- a/test/md/example-document.md.json
+++ b/test/md/example-document.md.json
@@ -1,8 +1,7 @@
 {
   "title": "Example Document",
   "body": {
-    "content": [
-      {
+    "content": [{
         "endIndex": 1,
         "sectionBreak": {
           "sectionStyle": {
@@ -15,16 +14,14 @@
         "startIndex": 1,
         "endIndex": 11,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1,
-              "endIndex": 11,
-              "textRun": {
-                "content": "Heading 1\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1,
+            "endIndex": 11,
+            "textRun": {
+              "content": "Heading 1\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.pur85qa8iw5l",
             "namedStyleType": "HEADING_1",
@@ -36,16 +33,14 @@
         "startIndex": 11,
         "endIndex": 12,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 11,
-              "endIndex": 12,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 11,
+            "endIndex": 12,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -56,16 +51,14 @@
         "startIndex": 12,
         "endIndex": 28,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 12,
-              "endIndex": 28,
-              "textRun": {
-                "content": "Heading level 2\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 12,
+            "endIndex": 28,
+            "textRun": {
+              "content": "Heading level 2\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.rwkjzl1scjzh",
             "namedStyleType": "HEADING_2",
@@ -77,16 +70,14 @@
         "startIndex": 28,
         "endIndex": 29,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 28,
-              "endIndex": 29,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 28,
+            "endIndex": 29,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -97,8 +88,7 @@
         "startIndex": 29,
         "endIndex": 235,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 29,
               "endIndex": 67,
               "textRun": {
@@ -267,16 +257,14 @@
         "startIndex": 235,
         "endIndex": 236,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 235,
-              "endIndex": 236,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 235,
+            "endIndex": 236,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -287,16 +275,14 @@
         "startIndex": 236,
         "endIndex": 267,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 236,
-              "endIndex": 267,
-              "textRun": {
-                "content": "Heading level 3 - with a table\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 236,
+            "endIndex": 267,
+            "textRun": {
+              "content": "Heading level 3 - with a table\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.t3tjnjbci85",
             "namedStyleType": "HEADING_3",
@@ -308,16 +294,14 @@
         "startIndex": 267,
         "endIndex": 268,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 267,
-              "endIndex": 268,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 267,
+            "endIndex": 268,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -330,120 +314,114 @@
         "table": {
           "rows": 2,
           "columns": 5,
-          "tableRows": [
-            {
+          "tableRows": [{
               "startIndex": 269,
               "endIndex": 325,
-              "tableCells": [
-                {
+              "tableCells": [{
                   "startIndex": 270,
                   "endIndex": 281,
-                  "content": [
-                    {
-                      "startIndex": 271,
-                      "endIndex": 281,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 271,
-                            "endIndex": 281,
-                            "textRun": {
-                              "content": "Heading 1\n",
-                              "textStyle": {
-                                "foregroundColor": {
-                                  "color": {
-                                    "rgbColor": {
-                                      "red": 1,
-                                      "green": 1,
-                                      "blue": 1
-                                    }
-                                  }
+                  "content": [{
+                    "startIndex": 271,
+                    "endIndex": 281,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 271,
+                        "endIndex": 281,
+                        "textRun": {
+                          "content": "Heading 1\n",
+                          "textStyle": {
+                            "foregroundColor": {
+                              "color": {
+                                "rgbColor": {
+                                  "red": 1,
+                                  "green": 1,
+                                  "blue": 1
                                 }
                               }
                             }
                           }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "CENTER",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "CENTER",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -478,112 +456,108 @@
                 {
                   "startIndex": 281,
                   "endIndex": 292,
-                  "content": [
-                    {
-                      "startIndex": 282,
-                      "endIndex": 292,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 282,
-                            "endIndex": 292,
-                            "textRun": {
-                              "content": "Heading 2\n",
-                              "textStyle": {
-                                "foregroundColor": {
-                                  "color": {
-                                    "rgbColor": {
-                                      "red": 1,
-                                      "green": 1,
-                                      "blue": 1
-                                    }
-                                  }
+                  "content": [{
+                    "startIndex": 282,
+                    "endIndex": 292,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 282,
+                        "endIndex": 292,
+                        "textRun": {
+                          "content": "Heading 2\n",
+                          "textStyle": {
+                            "foregroundColor": {
+                              "color": {
+                                "rgbColor": {
+                                  "red": 1,
+                                  "green": 1,
+                                  "blue": 1
                                 }
                               }
                             }
                           }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "CENTER",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "CENTER",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -618,112 +592,108 @@
                 {
                   "startIndex": 292,
                   "endIndex": 303,
-                  "content": [
-                    {
-                      "startIndex": 293,
-                      "endIndex": 303,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 293,
-                            "endIndex": 303,
-                            "textRun": {
-                              "content": "Heading 3\n",
-                              "textStyle": {
-                                "foregroundColor": {
-                                  "color": {
-                                    "rgbColor": {
-                                      "red": 1,
-                                      "green": 1,
-                                      "blue": 1
-                                    }
-                                  }
+                  "content": [{
+                    "startIndex": 293,
+                    "endIndex": 303,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 293,
+                        "endIndex": 303,
+                        "textRun": {
+                          "content": "Heading 3\n",
+                          "textStyle": {
+                            "foregroundColor": {
+                              "color": {
+                                "rgbColor": {
+                                  "red": 1,
+                                  "green": 1,
+                                  "blue": 1
                                 }
                               }
                             }
                           }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "CENTER",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "CENTER",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -758,112 +728,108 @@
                 {
                   "startIndex": 303,
                   "endIndex": 314,
-                  "content": [
-                    {
-                      "startIndex": 304,
-                      "endIndex": 314,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 304,
-                            "endIndex": 314,
-                            "textRun": {
-                              "content": "Heading 4\n",
-                              "textStyle": {
-                                "foregroundColor": {
-                                  "color": {
-                                    "rgbColor": {
-                                      "red": 1,
-                                      "green": 1,
-                                      "blue": 1
-                                    }
-                                  }
+                  "content": [{
+                    "startIndex": 304,
+                    "endIndex": 314,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 304,
+                        "endIndex": 314,
+                        "textRun": {
+                          "content": "Heading 4\n",
+                          "textStyle": {
+                            "foregroundColor": {
+                              "color": {
+                                "rgbColor": {
+                                  "red": 1,
+                                  "green": 1,
+                                  "blue": 1
                                 }
                               }
                             }
                           }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "CENTER",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "CENTER",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -898,112 +864,108 @@
                 {
                   "startIndex": 314,
                   "endIndex": 325,
-                  "content": [
-                    {
-                      "startIndex": 315,
-                      "endIndex": 325,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 315,
-                            "endIndex": 325,
-                            "textRun": {
-                              "content": "Heading 5\n",
-                              "textStyle": {
-                                "foregroundColor": {
-                                  "color": {
-                                    "rgbColor": {
-                                      "red": 1,
-                                      "green": 1,
-                                      "blue": 1
-                                    }
-                                  }
+                  "content": [{
+                    "startIndex": 315,
+                    "endIndex": 325,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 315,
+                        "endIndex": 325,
+                        "textRun": {
+                          "content": "Heading 5\n",
+                          "textStyle": {
+                            "foregroundColor": {
+                              "color": {
+                                "rgbColor": {
+                                  "red": 1,
+                                  "green": 1,
+                                  "blue": 1
                                 }
                               }
                             }
                           }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "CENTER",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "CENTER",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1045,106 +1007,101 @@
             {
               "startIndex": 325,
               "endIndex": 366,
-              "tableCells": [
-                {
+              "tableCells": [{
                   "startIndex": 326,
                   "endIndex": 334,
-                  "content": [
-                    {
-                      "startIndex": 327,
-                      "endIndex": 334,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 327,
-                            "endIndex": 334,
-                            "textRun": {
-                              "content": "Cell 1\n",
-                              "textStyle": {}
-                            }
-                          }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "START",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                  "content": [{
+                    "startIndex": 327,
+                    "endIndex": 334,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 327,
+                        "endIndex": 334,
+                        "textRun": {
+                          "content": "Cell 1\n",
+                          "textStyle": {}
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1171,102 +1128,98 @@
                 {
                   "startIndex": 334,
                   "endIndex": 342,
-                  "content": [
-                    {
-                      "startIndex": 335,
-                      "endIndex": 342,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 335,
-                            "endIndex": 342,
-                            "textRun": {
-                              "content": "Cell 2\n",
-                              "textStyle": {}
-                            }
-                          }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "START",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                  "content": [{
+                    "startIndex": 335,
+                    "endIndex": 342,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 335,
+                        "endIndex": 342,
+                        "textRun": {
+                          "content": "Cell 2\n",
+                          "textStyle": {}
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1293,102 +1246,98 @@
                 {
                   "startIndex": 342,
                   "endIndex": 350,
-                  "content": [
-                    {
-                      "startIndex": 343,
-                      "endIndex": 350,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 343,
-                            "endIndex": 350,
-                            "textRun": {
-                              "content": "Cell 3\n",
-                              "textStyle": {}
-                            }
-                          }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "START",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                  "content": [{
+                    "startIndex": 343,
+                    "endIndex": 350,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 343,
+                        "endIndex": 350,
+                        "textRun": {
+                          "content": "Cell 3\n",
+                          "textStyle": {}
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1415,102 +1364,98 @@
                 {
                   "startIndex": 350,
                   "endIndex": 358,
-                  "content": [
-                    {
-                      "startIndex": 351,
-                      "endIndex": 358,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 351,
-                            "endIndex": 358,
-                            "textRun": {
-                              "content": "Cell 4\n",
-                              "textStyle": {}
-                            }
-                          }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "START",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                  "content": [{
+                    "startIndex": 351,
+                    "endIndex": 358,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 351,
+                        "endIndex": 358,
+                        "textRun": {
+                          "content": "Cell 4\n",
+                          "textStyle": {}
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1537,102 +1482,98 @@
                 {
                   "startIndex": 358,
                   "endIndex": 366,
-                  "content": [
-                    {
-                      "startIndex": 359,
-                      "endIndex": 366,
-                      "paragraph": {
-                        "elements": [
-                          {
-                            "startIndex": 359,
-                            "endIndex": 366,
-                            "textRun": {
-                              "content": "Cell 5\n",
-                              "textStyle": {}
-                            }
-                          }
-                        ],
-                        "paragraphStyle": {
-                          "namedStyleType": "NORMAL_TEXT",
-                          "alignment": "START",
-                          "lineSpacing": 100,
-                          "direction": "LEFT_TO_RIGHT",
-                          "spacingMode": "COLLAPSE_LISTS",
-                          "spaceAbove": {
+                  "content": [{
+                    "startIndex": 359,
+                    "endIndex": 366,
+                    "paragraph": {
+                      "elements": [{
+                        "startIndex": 359,
+                        "endIndex": 366,
+                        "textRun": {
+                          "content": "Cell 5\n",
+                          "textStyle": {}
+                        }
+                      }],
+                      "paragraphStyle": {
+                        "namedStyleType": "NORMAL_TEXT",
+                        "alignment": "START",
+                        "lineSpacing": 100,
+                        "direction": "LEFT_TO_RIGHT",
+                        "spacingMode": "COLLAPSE_LISTS",
+                        "spaceAbove": {
+                          "unit": "PT"
+                        },
+                        "spaceBelow": {
+                          "unit": "PT"
+                        },
+                        "borderBetween": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "spaceBelow": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "borderBetween": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderTop": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderBottom": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderLeft": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "borderRight": {
-                            "color": {},
-                            "width": {
-                              "unit": "PT"
-                            },
-                            "padding": {
-                              "unit": "PT"
-                            },
-                            "dashStyle": "SOLID"
-                          },
-                          "indentFirstLine": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderTop": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "indentStart": {
+                          "padding": {
                             "unit": "PT"
                           },
-                          "indentEnd": {
+                          "dashStyle": "SOLID"
+                        },
+                        "borderBottom": {
+                          "color": {},
+                          "width": {
                             "unit": "PT"
                           },
-                          "keepLinesTogether": false,
-                          "keepWithNext": false,
-                          "avoidWidowAndOrphan": false,
-                          "shading": {
-                            "backgroundColor": {}
-                          }
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderLeft": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "borderRight": {
+                          "color": {},
+                          "width": {
+                            "unit": "PT"
+                          },
+                          "padding": {
+                            "unit": "PT"
+                          },
+                          "dashStyle": "SOLID"
+                        },
+                        "indentFirstLine": {
+                          "unit": "PT"
+                        },
+                        "indentStart": {
+                          "unit": "PT"
+                        },
+                        "indentEnd": {
+                          "unit": "PT"
+                        },
+                        "keepLinesTogether": false,
+                        "keepWithNext": false,
+                        "avoidWidowAndOrphan": false,
+                        "shading": {
+                          "backgroundColor": {}
                         }
                       }
                     }
-                  ],
+                  }],
                   "tableCellStyle": {
                     "rowSpan": 1,
                     "columnSpan": 1,
@@ -1665,8 +1606,7 @@
             }
           ],
           "tableStyle": {
-            "tableColumnProperties": [
-              {
+            "tableColumnProperties": [{
                 "widthType": "EVENLY_DISTRIBUTED"
               },
               {
@@ -1689,16 +1629,14 @@
         "startIndex": 367,
         "endIndex": 368,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 367,
-              "endIndex": 368,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 367,
+            "endIndex": 368,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1709,16 +1647,14 @@
         "startIndex": 368,
         "endIndex": 369,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 368,
-              "endIndex": 369,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 368,
+            "endIndex": 369,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1729,16 +1665,14 @@
         "startIndex": 369,
         "endIndex": 402,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 369,
-              "endIndex": 402,
-              "textRun": {
-                "content": "Heading 3 - a diagram with links\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 369,
+            "endIndex": 402,
+            "textRun": {
+              "content": "Heading 3 - a diagram with links\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.ambls07qke35",
             "namedStyleType": "HEADING_3",
@@ -1750,16 +1684,14 @@
         "startIndex": 402,
         "endIndex": 403,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 402,
-              "endIndex": 403,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 402,
+            "endIndex": 403,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1770,8 +1702,7 @@
         "startIndex": 403,
         "endIndex": 405,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 403,
               "endIndex": 404,
               "inlineObjectElement": {
@@ -1798,16 +1729,14 @@
         "startIndex": 405,
         "endIndex": 406,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 405,
-              "endIndex": 406,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 405,
+            "endIndex": 406,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1818,16 +1747,14 @@
         "startIndex": 406,
         "endIndex": 443,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 406,
-              "endIndex": 443,
-              "textRun": {
-                "content": "Heading 3 - with a Table of contents\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 406,
+            "endIndex": 443,
+            "textRun": {
+              "content": "Heading 3 - with a Table of contents\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.f49uy1gok3t5",
             "namedStyleType": "HEADING_3",
@@ -1839,16 +1766,14 @@
         "startIndex": 443,
         "endIndex": 444,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 443,
-              "endIndex": 444,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 443,
+            "endIndex": 444,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -1859,13 +1784,11 @@
         "startIndex": 444,
         "endIndex": 612,
         "tableOfContents": {
-          "content": [
-            {
+          "content": [{
               "startIndex": 445,
               "endIndex": 455,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 445,
                     "endIndex": 454,
                     "textRun": {
@@ -1957,8 +1880,7 @@
               "startIndex": 455,
               "endIndex": 471,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 455,
                     "endIndex": 470,
                     "textRun": {
@@ -2052,8 +1974,7 @@
               "startIndex": 471,
               "endIndex": 502,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 471,
                     "endIndex": 501,
                     "textRun": {
@@ -2147,8 +2068,7 @@
               "startIndex": 502,
               "endIndex": 535,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 502,
                     "endIndex": 534,
                     "textRun": {
@@ -2242,8 +2162,7 @@
               "startIndex": 535,
               "endIndex": 572,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 535,
                     "endIndex": 571,
                     "textRun": {
@@ -2309,8 +2228,7 @@
               "startIndex": 572,
               "endIndex": 587,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 572,
                     "endIndex": 586,
                     "textRun": {
@@ -2374,8 +2292,7 @@
               "startIndex": 587,
               "endIndex": 593,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 587,
                     "endIndex": 592,
                     "textRun": {
@@ -2441,8 +2358,7 @@
               "startIndex": 593,
               "endIndex": 611,
               "paragraph": {
-                "elements": [
-                  {
+                "elements": [{
                     "startIndex": 593,
                     "endIndex": 610,
                     "textRun": {
@@ -2515,16 +2431,14 @@
         "startIndex": 612,
         "endIndex": 613,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 612,
-              "endIndex": 613,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 612,
+            "endIndex": 613,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -2535,16 +2449,14 @@
         "startIndex": 613,
         "endIndex": 628,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 613,
-              "endIndex": 628,
-              "textRun": {
-                "content": "Other examples\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 613,
+            "endIndex": 628,
+            "textRun": {
+              "content": "Other examples\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.p5x030kzej77",
             "namedStyleType": "HEADING_1",
@@ -2556,16 +2468,14 @@
         "startIndex": 628,
         "endIndex": 629,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 628,
-              "endIndex": 629,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 628,
+            "endIndex": 629,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -2576,16 +2486,14 @@
         "startIndex": 629,
         "endIndex": 635,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 629,
-              "endIndex": 635,
-              "textRun": {
-                "content": "Image\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 629,
+            "endIndex": 635,
+            "textRun": {
+              "content": "Image\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.p56cvcv8bx70",
             "namedStyleType": "HEADING_2",
@@ -2597,8 +2505,7 @@
         "startIndex": 635,
         "endIndex": 637,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 635,
               "endIndex": 636,
               "inlineObjectElement": {
@@ -2629,8 +2536,7 @@
         "startIndex": 637,
         "endIndex": 639,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 637,
               "endIndex": 638,
               "inlineObjectElement": {
@@ -2661,16 +2567,14 @@
         "startIndex": 639,
         "endIndex": 657,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 639,
-              "endIndex": 657,
-              "textRun": {
-                "content": "Preformatted Text\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 639,
+            "endIndex": 657,
+            "textRun": {
+              "content": "Preformatted Text\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.74or9yzabmh6",
             "namedStyleType": "HEADING_2",
@@ -2682,16 +2586,14 @@
         "startIndex": 657,
         "endIndex": 658,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 657,
-              "endIndex": 658,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 657,
+            "endIndex": 658,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -2702,16 +2604,14 @@
         "startIndex": 658,
         "endIndex": 706,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 658,
-              "endIndex": 706,
-              "textRun": {
-                "content": "This is monospaced text. This should line up  |\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 658,
+            "endIndex": 706,
+            "textRun": {
+              "content": "This is monospaced text. This should line up  |\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.u4r0fzitq9go",
             "namedStyleType": "SUBTITLE",
@@ -2723,16 +2623,14 @@
         "startIndex": 706,
         "endIndex": 754,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 706,
-              "endIndex": 754,
-              "textRun": {
-                "content": "                                    with this |\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 706,
+            "endIndex": 754,
+            "textRun": {
+              "content": "                                    with this |\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.xfm80x6au75v",
             "namedStyleType": "SUBTITLE",
@@ -2744,16 +2642,14 @@
         "startIndex": 754,
         "endIndex": 757,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 754,
-              "endIndex": 757,
-              "textRun": {
-                "content": "  \n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 754,
+            "endIndex": 757,
+            "textRun": {
+              "content": "  \n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.kp9rgbt3gma0",
             "namedStyleType": "SUBTITLE",
@@ -2765,16 +2661,14 @@
         "startIndex": 757,
         "endIndex": 758,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 757,
-              "endIndex": 758,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 757,
+            "endIndex": 758,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -2785,16 +2679,14 @@
         "startIndex": 758,
         "endIndex": 763,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 758,
-              "endIndex": 763,
-              "textRun": {
-                "content": "Code\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 758,
+            "endIndex": 763,
+            "textRun": {
+              "content": "Code\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.niow4ogfp967",
             "namedStyleType": "HEADING_2",
@@ -2806,8 +2698,7 @@
         "startIndex": 763,
         "endIndex": 1254,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 763,
               "endIndex": 882,
               "textRun": {
@@ -3040,39 +2931,37 @@
         "startIndex": 1254,
         "endIndex": 1255,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1254,
-              "endIndex": 1255,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {
-                  "backgroundColor": {
-                    "color": {
-                      "rgbColor": {
-                        "red": 1,
-                        "green": 1,
-                        "blue": 1
-                      }
+          "elements": [{
+            "startIndex": 1254,
+            "endIndex": 1255,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {
+                "backgroundColor": {
+                  "color": {
+                    "rgbColor": {
+                      "red": 1,
+                      "green": 1,
+                      "blue": 1
                     }
-                  },
-                  "foregroundColor": {
-                    "color": {
-                      "rgbColor": {
-                        "red": 0.14117648,
-                        "green": 0.16078432,
-                        "blue": 0.18039216
-                      }
-                    }
-                  },
-                  "fontSize": {
-                    "magnitude": 12,
-                    "unit": "PT"
                   }
+                },
+                "foregroundColor": {
+                  "color": {
+                    "rgbColor": {
+                      "red": 0.14117648,
+                      "green": 0.16078432,
+                      "blue": 0.18039216
+                    }
+                  }
+                },
+                "fontSize": {
+                  "magnitude": 12,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3083,16 +2972,14 @@
         "startIndex": 1255,
         "endIndex": 1279,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1255,
-              "endIndex": 1279,
-              "textRun": {
-                "content": "Typescript / Javascript\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1255,
+            "endIndex": 1279,
+            "textRun": {
+              "content": "Typescript / Javascript\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.jt47qp4o5ir1",
             "namedStyleType": "HEADING_3",
@@ -3104,16 +2991,14 @@
         "startIndex": 1279,
         "endIndex": 1292,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1279,
-              "endIndex": 1292,
-              "textRun": {
-                "content": "{{markdown}}\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1279,
+            "endIndex": 1292,
+            "textRun": {
+              "content": "{{% markdown %}}\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3124,16 +3009,14 @@
         "startIndex": 1292,
         "endIndex": 1306,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1292,
-              "endIndex": 1306,
-              "textRun": {
-                "content": "```javascript\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1292,
+            "endIndex": 1306,
+            "textRun": {
+              "content": "```javascript\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3144,16 +3027,14 @@
         "startIndex": 1306,
         "endIndex": 1322,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1306,
-              "endIndex": 1322,
-              "textRun": {
-                "content": "class MyClass {\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1306,
+            "endIndex": 1322,
+            "textRun": {
+              "content": "class MyClass {\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3164,16 +3045,14 @@
         "startIndex": 1322,
         "endIndex": 1355,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1322,
-              "endIndex": 1355,
-              "textRun": {
-                "content": "  public static myValue: string;\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1322,
+            "endIndex": 1355,
+            "textRun": {
+              "content": "  public static myValue: string;\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3184,16 +3063,14 @@
         "startIndex": 1355,
         "endIndex": 1385,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1355,
-              "endIndex": 1385,
-              "textRun": {
-                "content": "  constructor(init: string) {\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1355,
+            "endIndex": 1385,
+            "textRun": {
+              "content": "  constructor(init: string) {\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3204,16 +3081,14 @@
         "startIndex": 1385,
         "endIndex": 1410,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1385,
-              "endIndex": 1410,
-              "textRun": {
-                "content": "    this.myValue = init;\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1385,
+            "endIndex": 1410,
+            "textRun": {
+              "content": "    this.myValue = init;\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3224,16 +3099,14 @@
         "startIndex": 1410,
         "endIndex": 1414,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1410,
-              "endIndex": 1414,
-              "textRun": {
-                "content": "  }\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1410,
+            "endIndex": 1414,
+            "textRun": {
+              "content": "  }\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3244,16 +3117,14 @@
         "startIndex": 1414,
         "endIndex": 1416,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1414,
-              "endIndex": 1416,
-              "textRun": {
-                "content": "}\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1414,
+            "endIndex": 1416,
+            "textRun": {
+              "content": "}\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3264,16 +3135,14 @@
         "startIndex": 1416,
         "endIndex": 1443,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1416,
-              "endIndex": 1443,
-              "textRun": {
-                "content": "import fs = require(\"fs\");\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1416,
+            "endIndex": 1443,
+            "textRun": {
+              "content": "import fs = require(\"fs\");\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3284,16 +3153,14 @@
         "startIndex": 1443,
         "endIndex": 1461,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1443,
-              "endIndex": 1461,
-              "textRun": {
-                "content": "module MyModule {\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1443,
+            "endIndex": 1461,
+            "textRun": {
+              "content": "module MyModule {\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3304,16 +3171,14 @@
         "startIndex": 1461,
         "endIndex": 1508,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1461,
-              "endIndex": 1508,
-              "textRun": {
-                "content": "  export interface MyInterface extends Other {\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1461,
+            "endIndex": 1508,
+            "textRun": {
+              "content": "  export interface MyInterface extends Other {\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3324,16 +3189,14 @@
         "startIndex": 1508,
         "endIndex": 1529,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1508,
-              "endIndex": 1529,
-              "textRun": {
-                "content": "    myProperty: any;\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1508,
+            "endIndex": 1529,
+            "textRun": {
+              "content": "    myProperty: any;\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3344,16 +3207,14 @@
         "startIndex": 1529,
         "endIndex": 1533,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1529,
-              "endIndex": 1533,
-              "textRun": {
-                "content": "  }\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1529,
+            "endIndex": 1533,
+            "textRun": {
+              "content": "  }\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3364,16 +3225,14 @@
         "startIndex": 1533,
         "endIndex": 1535,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1533,
-              "endIndex": 1535,
-              "textRun": {
-                "content": "}\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1533,
+            "endIndex": 1535,
+            "textRun": {
+              "content": "}\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3384,16 +3243,14 @@
         "startIndex": 1535,
         "endIndex": 1563,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1535,
-              "endIndex": 1563,
-              "textRun": {
-                "content": "declare magicNumber number;\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1535,
+            "endIndex": 1563,
+            "textRun": {
+              "content": "declare magicNumber number;\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3404,16 +3261,14 @@
         "startIndex": 1563,
         "endIndex": 1611,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1563,
-              "endIndex": 1611,
-              "textRun": {
-                "content": "myArray.forEach(() => { }); // fat arrow syntax\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1563,
+            "endIndex": 1611,
+            "textRun": {
+              "content": "myArray.forEach(() => { }); // fat arrow syntax\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3424,16 +3279,14 @@
         "startIndex": 1611,
         "endIndex": 1615,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1611,
-              "endIndex": 1615,
-              "textRun": {
-                "content": "```\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1611,
+            "endIndex": 1615,
+            "textRun": {
+              "content": "```\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3444,16 +3297,14 @@
         "startIndex": 1615,
         "endIndex": 1629,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1615,
-              "endIndex": 1629,
-              "textRun": {
-                "content": "{{/markdown}}\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1615,
+            "endIndex": 1629,
+            "textRun": {
+              "content": "{{% /markdown %}}\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3464,16 +3315,14 @@
         "startIndex": 1629,
         "endIndex": 1630,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1629,
-              "endIndex": 1630,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1629,
+            "endIndex": 1630,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3484,16 +3333,14 @@
         "startIndex": 1630,
         "endIndex": 1636,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1630,
-              "endIndex": 1636,
-              "textRun": {
-                "content": "Video\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1630,
+            "endIndex": 1636,
+            "textRun": {
+              "content": "Video\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.9b72fldy8rju",
             "namedStyleType": "HEADING_2",
@@ -3505,16 +3352,14 @@
         "startIndex": 1636,
         "endIndex": 1637,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1636,
-              "endIndex": 1637,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1636,
+            "endIndex": 1637,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3525,16 +3370,14 @@
         "startIndex": 1637,
         "endIndex": 1651,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1637,
-              "endIndex": 1651,
-              "textRun": {
-                "content": "From Youtube:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1637,
+            "endIndex": 1651,
+            "textRun": {
+              "content": "From Youtube:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3545,8 +3388,7 @@
         "startIndex": 1651,
         "endIndex": 1653,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1651,
               "endIndex": 1652,
               "inlineObjectElement": {
@@ -3587,8 +3429,7 @@
         "startIndex": 1653,
         "endIndex": 1708,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1653,
               "endIndex": 1707,
               "textRun": {
@@ -3629,16 +3470,14 @@
         "startIndex": 1708,
         "endIndex": 1709,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1708,
-              "endIndex": 1709,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1708,
+            "endIndex": 1709,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3649,16 +3488,14 @@
         "startIndex": 1709,
         "endIndex": 1726,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1709,
-              "endIndex": 1726,
-              "textRun": {
-                "content": "Horizontal Lines\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1709,
+            "endIndex": 1726,
+            "textRun": {
+              "content": "Horizontal Lines\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.q7zgn9e3oi6b",
             "namedStyleType": "HEADING_2",
@@ -3671,16 +3508,14 @@
         "startIndex": 1726,
         "endIndex": 1727,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1726,
-              "endIndex": 1727,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1726,
+            "endIndex": 1727,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3691,16 +3526,14 @@
         "startIndex": 1727,
         "endIndex": 1776,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1727,
-              "endIndex": 1776,
-              "textRun": {
-                "content": "This is some text separated by a horizontal line\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1727,
+            "endIndex": 1776,
+            "textRun": {
+              "content": "This is some text separated by a horizontal line\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3711,16 +3544,14 @@
         "startIndex": 1776,
         "endIndex": 1777,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1776,
-              "endIndex": 1777,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1776,
+            "endIndex": 1777,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3731,8 +3562,7 @@
         "startIndex": 1777,
         "endIndex": 1779,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1777,
               "endIndex": 1778,
               "horizontalRule": {
@@ -3758,16 +3588,14 @@
         "startIndex": 1779,
         "endIndex": 1780,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1779,
-              "endIndex": 1780,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1779,
+            "endIndex": 1780,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3778,16 +3606,14 @@
         "startIndex": 1780,
         "endIndex": 1815,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1780,
-              "endIndex": 1815,
-              "textRun": {
-                "content": "This is after the horizontal line.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1780,
+            "endIndex": 1815,
+            "textRun": {
+              "content": "This is after the horizontal line.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3798,16 +3624,14 @@
         "startIndex": 1815,
         "endIndex": 1816,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1815,
-              "endIndex": 1816,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1815,
+            "endIndex": 1816,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -3818,16 +3642,14 @@
         "startIndex": 1816,
         "endIndex": 1826,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1816,
-              "endIndex": 1826,
-              "textRun": {
-                "content": "Equations\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1816,
+            "endIndex": 1826,
+            "textRun": {
+              "content": "Equations\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.guzoh1oxt0s4",
             "namedStyleType": "HEADING_2",
@@ -3839,16 +3661,14 @@
         "startIndex": 1826,
         "endIndex": 1860,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1826,
-              "endIndex": 1860,
-              "textRun": {
-                "content": "\tUsing the actual equation object\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1826,
+            "endIndex": 1860,
+            "textRun": {
+              "content": "\tUsing the actual equation object\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.xupy2b5teiu",
             "namedStyleType": "HEADING_3",
@@ -3860,8 +3680,7 @@
         "startIndex": 1860,
         "endIndex": 1871,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1860,
               "endIndex": 1870,
               "equation": {}
@@ -3893,16 +3712,14 @@
         "startIndex": 1871,
         "endIndex": 1872,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1871,
-              "endIndex": 1872,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1871,
+            "endIndex": 1872,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3921,16 +3738,14 @@
         "startIndex": 1872,
         "endIndex": 1888,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1872,
-              "endIndex": 1888,
-              "textRun": {
-                "content": "Text equivalent\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1872,
+            "endIndex": 1888,
+            "textRun": {
+              "content": "Text equivalent\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.decz1axq5tzn",
             "namedStyleType": "HEADING_3",
@@ -3950,8 +3765,7 @@
         "startIndex": 1888,
         "endIndex": 1894,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1888,
               "endIndex": 1892,
               "textRun": {
@@ -3991,16 +3805,14 @@
         "startIndex": 1894,
         "endIndex": 1904,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1894,
-              "endIndex": 1904,
-              "textRun": {
-                "content": "Footnotes\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1894,
+            "endIndex": 1904,
+            "textRun": {
+              "content": "Footnotes\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "headingId": "h.44175oezvk2",
             "namedStyleType": "HEADING_2",
@@ -4012,8 +3824,7 @@
         "startIndex": 1904,
         "endIndex": 1948,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1904,
               "endIndex": 1905,
               "footnoteReference": {
@@ -4041,16 +3852,14 @@
         "startIndex": 1948,
         "endIndex": 1949,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1948,
-              "endIndex": 1949,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1948,
+            "endIndex": 1949,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -4061,16 +3870,14 @@
         "startIndex": 1949,
         "endIndex": 1974,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1949,
-              "endIndex": 1974,
-              "textRun": {
-                "content": "This is some other data.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1949,
+            "endIndex": 1974,
+            "textRun": {
+              "content": "This is some other data.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -4082,12 +3889,10 @@
   "footnotes": {
     "kix.6ef0di9qd512": {
       "footnoteId": "kix.6ef0di9qd512",
-      "content": [
-        {
+      "content": [{
           "endIndex": 107,
           "paragraph": {
-            "elements": [
-              {
+            "elements": [{
                 "endIndex": 105,
                 "textRun": {
                   "content": " Footnotes should display as a footnote, and should always display at the very end of the document (page)",
@@ -4125,21 +3930,19 @@
           "startIndex": 107,
           "endIndex": 108,
           "paragraph": {
-            "elements": [
-              {
-                "startIndex": 107,
-                "endIndex": 108,
-                "textRun": {
-                  "content": "\n",
-                  "textStyle": {
-                    "fontSize": {
-                      "magnitude": 10,
-                      "unit": "PT"
-                    }
+            "elements": [{
+              "startIndex": 107,
+              "endIndex": 108,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {
+                  "fontSize": {
+                    "magnitude": 10,
+                    "unit": "PT"
                   }
                 }
               }
-            ],
+            }],
             "paragraphStyle": {
               "namedStyleType": "NORMAL_TEXT",
               "lineSpacing": 100,
@@ -4151,16 +3954,14 @@
           "startIndex": 108,
           "endIndex": 109,
           "paragraph": {
-            "elements": [
-              {
-                "startIndex": 108,
-                "endIndex": 109,
-                "textRun": {
-                  "content": "\n",
-                  "textStyle": {}
-                }
+            "elements": [{
+              "startIndex": 108,
+              "endIndex": 109,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
               }
-            ],
+            }],
             "paragraphStyle": {
               "namedStyleType": "NORMAL_TEXT",
               "direction": "LEFT_TO_RIGHT"
@@ -4171,16 +3972,14 @@
           "startIndex": 109,
           "endIndex": 110,
           "paragraph": {
-            "elements": [
-              {
-                "startIndex": 109,
-                "endIndex": 110,
-                "textRun": {
-                  "content": "\n",
-                  "textStyle": {}
-                }
+            "elements": [{
+              "startIndex": 109,
+              "endIndex": 110,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
               }
-            ],
+            }],
             "paragraphStyle": {
               "namedStyleType": "NORMAL_TEXT",
               "direction": "LEFT_TO_RIGHT"
@@ -4191,16 +3990,14 @@
           "startIndex": 110,
           "endIndex": 111,
           "paragraph": {
-            "elements": [
-              {
-                "startIndex": 110,
-                "endIndex": 111,
-                "textRun": {
-                  "content": "\n",
-                  "textStyle": {}
-                }
+            "elements": [{
+              "startIndex": 110,
+              "endIndex": 111,
+              "textRun": {
+                "content": "\n",
+                "textStyle": {}
               }
-            ],
+            }],
             "paragraphStyle": {
               "namedStyleType": "NORMAL_TEXT",
               "direction": "LEFT_TO_RIGHT"
@@ -4243,8 +4040,7 @@
     }
   },
   "namedStyles": {
-    "styles": [
-      {
+    "styles": [{
         "namedStyleType": "NORMAL_TEXT",
         "textStyle": {
           "bold": false,

--- a/test/md/intro-to-the-system.md.json
+++ b/test/md/intro-to-the-system.md.json
@@ -1,8 +1,7 @@
 {
   "title": "Intro to the System",
   "body": {
-    "content": [
-      {
+    "content": [{
         "endIndex": 1,
         "sectionBreak": {
           "sectionStyle": {
@@ -15,16 +14,14 @@
         "startIndex": 1,
         "endIndex": 310,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1,
-              "endIndex": 310,
-              "textRun": {
-                "content": "The following page addresses the basic navigation and functionality of {system-name } . If you're a current user, you'll notice some things might look a little different. We've improved the user experience — making {system-name } even more intuitive and efficient.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1,
+            "endIndex": 310,
+            "textRun": {
+              "content": "The following page addresses the basic navigation and functionality of {{% system-name %}} . If you're a current user, you'll notice some things might look a little different. We've improved the user experience — making {{% system-name %}} even more intuitive and efficient.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -88,16 +85,14 @@
         "startIndex": 310,
         "endIndex": 311,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 310,
-              "endIndex": 311,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 310,
+            "endIndex": 311,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -161,23 +156,21 @@
         "startIndex": 311,
         "endIndex": 326,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 311,
-              "endIndex": 326,
-              "textRun": {
-                "content": "User Interface\n",
-                "textStyle": {
-                  "bold": true,
-                  "italic": false,
-                  "fontSize": {
-                    "magnitude": 18,
-                    "unit": "PT"
-                  }
+          "elements": [{
+            "startIndex": 311,
+            "endIndex": 326,
+            "textRun": {
+              "content": "User Interface\n",
+              "textStyle": {
+                "bold": true,
+                "italic": false,
+                "fontSize": {
+                  "magnitude": 18,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_2",
             "direction": "LEFT_TO_RIGHT",
@@ -244,16 +237,14 @@
         "startIndex": 326,
         "endIndex": 592,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 326,
-              "endIndex": 592,
-              "textRun": {
-                "content": "The linked text on the left side of the system features a number of tabs that link to different areas of the system. This menu can be hidden to provide more real estate, or pinned open with the pin icon. The first tab on the left side menu is the to the Quick View.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 326,
+            "endIndex": 592,
+            "textRun": {
+              "content": "The linked text on the left side of the system features a number of tabs that link to different areas of the system. This menu can be hidden to provide more real estate, or pinned open with the pin icon. The first tab on the left side menu is the to the Quick View.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -317,16 +308,14 @@
         "startIndex": 592,
         "endIndex": 614,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 592,
-              "endIndex": 614,
-              "textRun": {
-                "content": "Starting on the left:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 592,
+            "endIndex": 614,
+            "textRun": {
+              "content": "Starting on the left:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -390,16 +379,14 @@
         "startIndex": 614,
         "endIndex": 668,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 614,
-              "endIndex": 668,
-              "textRun": {
-                "content": "The Menu button displays or hides the left side menu.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 614,
+            "endIndex": 668,
+            "textRun": {
+              "content": "The Menu button displays or hides the left side menu.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -475,16 +462,14 @@
         "startIndex": 668,
         "endIndex": 845,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 668,
-              "endIndex": 845,
-              "textRun": {
-                "content": "The Home button brings you back to this page from any page in {system-name } while the default is the Quick View page, a user can specify their home page.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 668,
+            "endIndex": 845,
+            "textRun": {
+              "content": "The Home button brings you back to this page from any page in {{% system-name %}} while the default is the Quick View page, a user can specify their home page.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -560,16 +545,14 @@
         "startIndex": 845,
         "endIndex": 969,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 845,
-              "endIndex": 969,
-              "textRun": {
-                "content": "The Doc Queue indicates open designated lists for tasks, documents, and other information assigned to a user or department.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 845,
+            "endIndex": 969,
+            "textRun": {
+              "content": "The Doc Queue indicates open designated lists for tasks, documents, and other information assigned to a user or department.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -645,16 +628,14 @@
         "startIndex": 969,
         "endIndex": 983,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 969,
-              "endIndex": 983,
-              "textRun": {
-                "content": "To the right:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 969,
+            "endIndex": 983,
+            "textRun": {
+              "content": "To the right:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -718,16 +699,14 @@
         "startIndex": 983,
         "endIndex": 1031,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 983,
-              "endIndex": 1031,
-              "textRun": {
-                "content": "The signed-in user and their role is displayed.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 983,
+            "endIndex": 1031,
+            "textRun": {
+              "content": "The signed-in user and their role is displayed.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -803,16 +782,14 @@
         "startIndex": 1031,
         "endIndex": 1234,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1031,
-              "endIndex": 1234,
-              "textRun": {
-                "content": "The link icon indicates whether or not the signed in user is connected to the database. This area also displays messages to notify a user if another user is working in a document that is currently open.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1031,
+            "endIndex": 1234,
+            "textRun": {
+              "content": "The link icon indicates whether or not the signed in user is connected to the database. This area also displays messages to notify a user if another user is working in a document that is currently open.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -888,16 +865,14 @@
         "startIndex": 1234,
         "endIndex": 1338,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1234,
-              "endIndex": 1338,
-              "textRun": {
-                "content": "The question mark icon links to available help documentation — if help is available the icon is orange.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1234,
+            "endIndex": 1338,
+            "textRun": {
+              "content": "The question mark icon links to available help documentation — if help is available the icon is orange.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -973,16 +948,14 @@
         "startIndex": 1338,
         "endIndex": 1339,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1338,
-              "endIndex": 1339,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1338,
+            "endIndex": 1339,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1046,23 +1019,21 @@
         "startIndex": 1339,
         "endIndex": 1350,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1339,
-              "endIndex": 1350,
-              "textRun": {
-                "content": "Quick View\n",
-                "textStyle": {
-                  "bold": true,
-                  "italic": false,
-                  "fontSize": {
-                    "magnitude": 14,
-                    "unit": "PT"
-                  }
+          "elements": [{
+            "startIndex": 1339,
+            "endIndex": 1350,
+            "textRun": {
+              "content": "Quick View\n",
+              "textStyle": {
+                "bold": true,
+                "italic": false,
+                "fontSize": {
+                  "magnitude": 14,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_3",
             "direction": "LEFT_TO_RIGHT",
@@ -1129,16 +1100,14 @@
         "startIndex": 1350,
         "endIndex": 1771,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1350,
-              "endIndex": 1771,
-              "textRun": {
-                "content": "Most users see this page when they sign in to the system. It is a customizable dashboard featuring information from throughout the system pertinent to the user’s daily job functions. This information is organized into areas called Portlets. Portlets can be collapsed and expanded — or moved by dragging and dropping, so what's important to a specific user can be placed at the top. You can also remove Portlets entirely.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1350,
+            "endIndex": 1771,
+            "textRun": {
+              "content": "Most users see this page when they sign in to the system. It is a customizable dashboard featuring information from throughout the system pertinent to the user’s daily job functions. This information is organized into areas called Portlets. Portlets can be collapsed and expanded — or moved by dragging and dropping, so what's important to a specific user can be placed at the top. You can also remove Portlets entirely.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1202,8 +1171,7 @@
         "startIndex": 1771,
         "endIndex": 1773,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 1771,
               "endIndex": 1772,
               "inlineObjectElement": {
@@ -1283,16 +1251,14 @@
         "startIndex": 1773,
         "endIndex": 1774,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1773,
-              "endIndex": 1774,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1773,
+            "endIndex": 1774,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1356,23 +1322,21 @@
         "startIndex": 1774,
         "endIndex": 1782,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1774,
-              "endIndex": 1782,
-              "textRun": {
-                "content": "E-Chart\n",
-                "textStyle": {
-                  "bold": true,
-                  "italic": false,
-                  "fontSize": {
-                    "magnitude": 14,
-                    "unit": "PT"
-                  }
+          "elements": [{
+            "startIndex": 1774,
+            "endIndex": 1782,
+            "textRun": {
+              "content": "E-Chart\n",
+              "textStyle": {
+                "bold": true,
+                "italic": false,
+                "fontSize": {
+                  "magnitude": 14,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_3",
             "direction": "LEFT_TO_RIGHT",
@@ -1439,16 +1403,14 @@
         "startIndex": 1782,
         "endIndex": 2099,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1782,
-              "endIndex": 2099,
-              "textRun": {
-                "content": "Searching for a patient's chart still begins at the E-Chart tab. The overall look and feel of the patient search matches the new {system-name } styling, including the tabs. The E-Chart defaults to the Patient Summary page. The Patient Summary displays data in portlets much like the Quick View.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1782,
+            "endIndex": 2099,
+            "textRun": {
+              "content": "Searching for a patient's chart still begins at the E-Chart tab. The overall look and feel of the patient search matches the new {{% system-name %}} styling, including the tabs. The E-Chart defaults to the Patient Summary page. The Patient Summary displays data in portlets much like the Quick View.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1512,16 +1474,14 @@
         "startIndex": 2099,
         "endIndex": 2160,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2099,
-              "endIndex": 2160,
-              "textRun": {
-                "content": "E-chart navigation includes a number of toolbars, including:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2099,
+            "endIndex": 2160,
+            "textRun": {
+              "content": "E-chart navigation includes a number of toolbars, including:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1585,16 +1545,14 @@
         "startIndex": 2160,
         "endIndex": 2315,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2160,
-              "endIndex": 2315,
-              "textRun": {
-                "content": "The Tab toolbar, which navigates through the chart. The active tab is a solid color — some tabs have drop down navigation indicated by a mark in the lower\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2160,
+            "endIndex": 2315,
+            "textRun": {
+              "content": "The Tab toolbar, which navigates through the chart. The active tab is a solid color — some tabs have drop down navigation indicated by a mark in the lower\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1670,16 +1628,14 @@
         "startIndex": 2315,
         "endIndex": 2329,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2315,
-              "endIndex": 2329,
-              "textRun": {
-                "content": "right corner.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2315,
+            "endIndex": 2329,
+            "textRun": {
+              "content": "right corner.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1743,16 +1699,14 @@
         "startIndex": 2329,
         "endIndex": 2409,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2329,
-              "endIndex": 2409,
-              "textRun": {
-                "content": "The Patient Info toolbar displays the patient’s name and medical record number.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2329,
+            "endIndex": 2409,
+            "textRun": {
+              "content": "The Patient Info toolbar displays the patient’s name and medical record number.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1828,16 +1782,14 @@
         "startIndex": 2409,
         "endIndex": 2552,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2409,
-              "endIndex": 2552,
-              "textRun": {
-                "content": "Also available in the Patient Info toolbar is the side chart icon, which displays patient historical information such as medical records, past\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2409,
+            "endIndex": 2552,
+            "textRun": {
+              "content": "Also available in the Patient Info toolbar is the side chart icon, which displays patient historical information such as medical records, past\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1914,16 +1866,14 @@
         "startIndex": 2552,
         "endIndex": 2584,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2552,
-              "endIndex": 2584,
-              "textRun": {
-                "content": "encounters, notes and comments.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2552,
+            "endIndex": 2584,
+            "textRun": {
+              "content": "encounters, notes and comments.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -1987,16 +1937,14 @@
         "startIndex": 2584,
         "endIndex": 2677,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2584,
-              "endIndex": 2677,
-              "textRun": {
-                "content": "The Patient Extended Toolbar displays demographic, encounter, and other related information.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2584,
+            "endIndex": 2677,
+            "textRun": {
+              "content": "The Patient Extended Toolbar displays demographic, encounter, and other related information.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2072,16 +2020,14 @@
         "startIndex": 2677,
         "endIndex": 2781,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2677,
-              "endIndex": 2781,
-              "textRun": {
-                "content": "The Alerts toolbar displays available alert information — such as allergies or do not release requests.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2677,
+            "endIndex": 2781,
+            "textRun": {
+              "content": "The Alerts toolbar displays available alert information — such as allergies or do not release requests.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2157,16 +2103,14 @@
         "startIndex": 2781,
         "endIndex": 2865,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2781,
-              "endIndex": 2865,
-              "textRun": {
-                "content": "The Encounter toolbar displays information and links to the open patient encounter.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2781,
+            "endIndex": 2865,
+            "textRun": {
+              "content": "The Encounter toolbar displays information and links to the open patient encounter.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2242,8 +2186,7 @@
         "startIndex": 2865,
         "endIndex": 2867,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 2865,
               "endIndex": 2866,
               "inlineObjectElement": {
@@ -2323,16 +2266,14 @@
         "startIndex": 2867,
         "endIndex": 2868,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2867,
-              "endIndex": 2868,
-              "textRun": {
-                "content": "\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2867,
+            "endIndex": 2868,
+            "textRun": {
+              "content": "\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2396,23 +2337,21 @@
         "startIndex": 2868,
         "endIndex": 2886,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2868,
-              "endIndex": 2886,
-              "textRun": {
-                "content": "Dynamic Encounter\n",
-                "textStyle": {
-                  "bold": true,
-                  "italic": false,
-                  "fontSize": {
-                    "magnitude": 14,
-                    "unit": "PT"
-                  }
+          "elements": [{
+            "startIndex": 2868,
+            "endIndex": 2886,
+            "textRun": {
+              "content": "Dynamic Encounter\n",
+              "textStyle": {
+                "bold": true,
+                "italic": false,
+                "fontSize": {
+                  "magnitude": 14,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_3",
             "direction": "LEFT_TO_RIGHT",
@@ -2479,16 +2418,14 @@
         "startIndex": 2886,
         "endIndex": 3261,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 2886,
-              "endIndex": 3261,
-              "textRun": {
-                "content": "As its name suggests, the dynamic encounter can be customized on the fly. The Show hidden section list button displays any available section options that do not already appear on the page. The dynamic encounter features the same patient-related toolbars as the E-Chart. The Show exam sections pop-up window allows the user click on a section name to add it to the encounter.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 2886,
+            "endIndex": 3261,
+            "textRun": {
+              "content": "As its name suggests, the dynamic encounter can be customized on the fly. The Show hidden section list button displays any available section options that do not already appear on the page. The dynamic encounter features the same patient-related toolbars as the E-Chart. The Show exam sections pop-up window allows the user click on a section name to add it to the encounter.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2552,16 +2489,14 @@
         "startIndex": 3261,
         "endIndex": 3464,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3261,
-              "endIndex": 3464,
-              "textRun": {
-                "content": "Note: Multiple users can open a dynamic encounter at the same time. A warning message displays in red at the top of the dynamic encounter to notify the logged in user if another user owns the encounter.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3261,
+            "endIndex": 3464,
+            "textRun": {
+              "content": "Note: Multiple users can open a dynamic encounter at the same time. A warning message displays in red at the top of the dynamic encounter to notify the logged in user if another user owns the encounter.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2625,16 +2560,14 @@
         "startIndex": 3464,
         "endIndex": 3606,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3464,
-              "endIndex": 3606,
-              "textRun": {
-                "content": "The dynamic encounter is divided into a number of sections. Tabs that link to each section appear in the tab toolbar. These sections include:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3464,
+            "endIndex": 3606,
+            "textRun": {
+              "content": "The dynamic encounter is divided into a number of sections. Tabs that link to each section appear in the tab toolbar. These sections include:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2698,16 +2631,14 @@
         "startIndex": 3606,
         "endIndex": 3617,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3606,
-              "endIndex": 3617,
-              "textRun": {
-                "content": "Subjective\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3606,
+            "endIndex": 3617,
+            "textRun": {
+              "content": "Subjective\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2783,16 +2714,14 @@
         "startIndex": 3617,
         "endIndex": 3627,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3617,
-              "endIndex": 3627,
-              "textRun": {
-                "content": "Objective\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3617,
+            "endIndex": 3627,
+            "textRun": {
+              "content": "Objective\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2868,16 +2797,14 @@
         "startIndex": 3627,
         "endIndex": 3638,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3627,
-              "endIndex": 3638,
-              "textRun": {
-                "content": "Assessment\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3627,
+            "endIndex": 3638,
+            "textRun": {
+              "content": "Assessment\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -2953,16 +2880,14 @@
         "startIndex": 3638,
         "endIndex": 3643,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3638,
-              "endIndex": 3643,
-              "textRun": {
-                "content": "Plan\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3638,
+            "endIndex": 3643,
+            "textRun": {
+              "content": "Plan\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3038,16 +2963,14 @@
         "startIndex": 3643,
         "endIndex": 3651,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3643,
-              "endIndex": 3651,
-              "textRun": {
-                "content": "Summary\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3643,
+            "endIndex": 3651,
+            "textRun": {
+              "content": "Summary\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3123,16 +3046,14 @@
         "startIndex": 3651,
         "endIndex": 3776,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3651,
-              "endIndex": 3776,
-              "textRun": {
-                "content": "Click the section heading to open a section for editing. When the section is open for editing, the following buttons appear:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3651,
+            "endIndex": 3776,
+            "textRun": {
+              "content": "Click the section heading to open a section for editing. When the section is open for editing, the following buttons appear:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3196,16 +3117,14 @@
         "startIndex": 3776,
         "endIndex": 3855,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3776,
-              "endIndex": 3855,
-              "textRun": {
-                "content": "Next - Saves data entered into the current section and opens the next section.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3776,
+            "endIndex": 3855,
+            "textRun": {
+              "content": "Next - Saves data entered into the current section and opens the next section.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3281,16 +3200,14 @@
         "startIndex": 3855,
         "endIndex": 3915,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3855,
-              "endIndex": 3915,
-              "textRun": {
-                "content": "Cancel - Closes the section. Any data entered is not saved.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3855,
+            "endIndex": 3915,
+            "textRun": {
+              "content": "Cancel - Closes the section. Any data entered is not saved.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3366,16 +3283,14 @@
         "startIndex": 3915,
         "endIndex": 3970,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3915,
-              "endIndex": 3970,
-              "textRun": {
-                "content": "Hide section - Removes the section from the encounter.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3915,
+            "endIndex": 3970,
+            "textRun": {
+              "content": "Hide section - Removes the section from the encounter.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3451,16 +3366,14 @@
         "startIndex": 3970,
         "endIndex": 4186,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 3970,
-              "endIndex": 4186,
-              "textRun": {
-                "content": "When a section is open for editing, a Next button appears at the bottom. Click the next button to open the next available section for editing. Some sections have display options. The following options are available:\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 3970,
+            "endIndex": 4186,
+            "textRun": {
+              "content": "When a section is open for editing, a Next button appears at the bottom. Click the next button to open the next available section for editing. Some sections have display options. The following options are available:\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3524,16 +3437,14 @@
         "startIndex": 4186,
         "endIndex": 4235,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 4186,
-              "endIndex": 4235,
-              "textRun": {
-                "content": "Summary view - Displays data in a bulleted list.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 4186,
+            "endIndex": 4235,
+            "textRun": {
+              "content": "Summary view - Displays data in a bulleted list.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3609,16 +3520,14 @@
         "startIndex": 4235,
         "endIndex": 4275,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 4235,
-              "endIndex": 4275,
-              "textRun": {
-                "content": "Detail view - Displays data in a table.\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 4235,
+            "endIndex": 4275,
+            "textRun": {
+              "content": "Detail view - Displays data in a table.\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT",
@@ -3694,8 +3603,7 @@
         "startIndex": 4275,
         "endIndex": 4277,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 4275,
               "endIndex": 4276,
               "inlineObjectElement": {
@@ -3779,23 +3687,21 @@
         "startIndex": 4277,
         "endIndex": 4291,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 4277,
-              "endIndex": 4291,
-              "textRun": {
-                "content": "Related Pages\n",
-                "textStyle": {
-                  "bold": true,
-                  "italic": false,
-                  "fontSize": {
-                    "magnitude": 18,
-                    "unit": "PT"
-                  }
+          "elements": [{
+            "startIndex": 4277,
+            "endIndex": 4291,
+            "textRun": {
+              "content": "Related Pages\n",
+              "textStyle": {
+                "bold": true,
+                "italic": false,
+                "fontSize": {
+                  "magnitude": 18,
+                  "unit": "PT"
                 }
               }
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "HEADING_2",
             "direction": "LEFT_TO_RIGHT",
@@ -3862,8 +3768,7 @@
         "startIndex": 4291,
         "endIndex": 4306,
         "paragraph": {
-          "elements": [
-            {
+          "elements": [{
               "startIndex": 4291,
               "endIndex": 4305,
               "textRun": {
@@ -4009,8 +3914,7 @@
     }
   },
   "namedStyles": {
-    "styles": [
-      {
+    "styles": [{
         "namedStyleType": "NORMAL_TEXT",
         "textStyle": {},
         "paragraphStyle": {
@@ -4614,8 +4518,7 @@
   "lists": {
     "kix.list.4": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -4917,8 +4820,7 @@
     },
     "kix.list.5": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -5220,8 +5122,7 @@
     },
     "kix.list.6": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -5523,8 +5424,7 @@
     },
     "kix.list.7": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -5826,8 +5726,7 @@
     },
     "kix.list.8": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -6129,8 +6028,7 @@
     },
     "kix.list.9": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -6432,8 +6330,7 @@
     },
     "kix.list.1": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -6735,8 +6632,7 @@
     },
     "kix.list.2": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -7038,8 +6934,7 @@
     },
     "kix.list.3": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {
@@ -7341,8 +7236,7 @@
     },
     "kix.list.a": {
       "listProperties": {
-        "nestingLevels": [
-          {
+        "nestingLevels": [{
             "bulletAlignment": "START",
             "glyphType": "GLYPH_TYPE_UNSPECIFIED",
             "indentFirstLine": {

--- a/test/md/quotes.md.json
+++ b/test/md/quotes.md.json
@@ -1,8 +1,7 @@
 {
   "title": "Test Page",
   "body": {
-    "content": [
-      {
+    "content": [{
         "endIndex": 1,
         "sectionBreak": {
           "sectionStyle": {
@@ -15,16 +14,14 @@
         "startIndex": 1,
         "endIndex": 43,
         "paragraph": {
-          "elements": [
-            {
-              "startIndex": 1,
-              "endIndex": 43,
-              "textRun": {
-                "content": "{only sys=\"sysname” }\n{only sys=’sysname’ }\n",
-                "textStyle": {}
-              }
+          "elements": [{
+            "startIndex": 1,
+            "endIndex": 43,
+            "textRun": {
+              "content": "{{% only sys=\"sysname” %}}\n{{% only sys=’sysname’ %}}\n",
+              "textStyle": {}
             }
-          ],
+          }],
           "paragraphStyle": {
             "namedStyleType": "NORMAL_TEXT",
             "direction": "LEFT_TO_RIGHT"
@@ -66,8 +63,7 @@
     }
   },
   "namedStyles": {
-    "styles": [
-      {
+    "styles": [{
         "namedStyleType": "NORMAL_TEXT",
         "textStyle": {
           "bold": false,


### PR DESCRIPTION
We have switched to just using Hugo's shortcode syntax in the Google Docs instead of parsing our own macro syntax.   The request was to have the shortcodes wrapped in italics (or they will be ignored and output plain text).  So I have some code that makes sure that extra italic lines do not end up being outputted. 