### PR TITLE
Added name from nav file to serve as menu item label

### DIFF
--- a/src/FrontMatterTransform.js
+++ b/src/FrontMatterTransform.js
@@ -39,11 +39,13 @@ export class FrontMatterTransform extends Transform {
 
     if (this.navigationHierarchy[this.file.id]) {
       const navigationData = this.navigationHierarchy[this.file.id];
+
       frontMatter += 'menu:\n';
       frontMatter += '    main:\n';
-      frontMatter += '        identifier: "' + navigationData.identifier +'"\n';
+      frontMatter += '        name: "' + navigationData.name + '"\n';
+      frontMatter += '        identifier: "' + navigationData.identifier + '"\n';
       if (navigationData.parent) {
-        frontMatter += '        parent: "' + navigationData.parent +'"\n';
+        frontMatter += '        parent: "' + navigationData.parent + '"\n';
       }
       frontMatter += '        weight: ' + navigationData.weight + '\n';
     }

--- a/src/NavigationTransform.js
+++ b/src/NavigationTransform.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import {Transform} from 'stream';
-import {PREFIX_LEVEL} from './MarkDownTransform';
+import { Transform } from 'stream';
+import { PREFIX_LEVEL } from './MarkDownTransform';
 
 export class NavigationTransform extends Transform {
 
@@ -34,24 +34,26 @@ export class NavigationTransform extends Transform {
     let counter = 30;
 
     for (const line of lines) {
+
       const level = line.replace(/^([\s]*).*$/, '$1').length / PREFIX_LEVEL.length;
 
       const squareBracketEnd = line.lastIndexOf(']');
       const bracketStart = line.indexOf('(', squareBracketEnd) + 1;
       let localPath = line.substr(bracketStart, line.indexOf(')', squareBracketEnd) - bracketStart);
+      let navLabel = line.substr(line.indexOf('[') + 1, line.indexOf(']') - (line.indexOf('[') + 1));
 
       switch (this.link_mode) {
-        case 'uglyURLs':
-          localPath = localPath.replace(/.html$/, '.md');
-          break;
+      case 'uglyURLs':
+        localPath = localPath.replace(/.html$/, '.md');
+        break;
 
-        case 'dirURLs':
-          localPath += '.md';
-          break;
+      case 'dirURLs':
+        localPath += '.md';
+        break;
 
-        case 'mdURLs':
-        default:
-          break;
+      case 'mdURLs':
+      default:
+        break;
       }
 
       const file = this.files.find(file => file.localPath === localPath);
@@ -60,6 +62,7 @@ export class NavigationTransform extends Transform {
         levels[level] = file;
 
         const hierarchyFrontMatter = {
+          name: navLabel,
           weight: counter,
           identifier: file.id
         };


### PR DESCRIPTION
Hugo needs an _index.md file to serve as the home page.  Giving the Google Doc the name of _index would make the sidebar nav entry show "_index".   This fix adds the label given in the .navigation file to the menu front matter and allows us to avoid this manual filename change.