### PR TITLE
git debug command line id_rsa setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ RUN cd /usr/src/app/apps/ui && npm install && npm run build
 
 WORKDIR "/usr/src/app"
 
+# Add the GIT_SSH_COMMAND to /etc/profile so that we can debug git issues from the command line
+RUN echo "export GIT_SSH_COMMAND='ssh -i \$(pwd | sed \'s/_transform//\')/.private/id_rsa'" >> /etc/profile
+
 CMD [ "sh", "-c", "wikigdrive --workdir /data server 3000" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN cd /usr/src/app/apps/ui && npm install && npm run build
 WORKDIR "/usr/src/app"
 
 # Add the GIT_SSH_COMMAND to /etc/profile so that we can debug git issues from the command line
-RUN echo "export GIT_SSH_COMMAND='ssh -i \$(pwd | sed \'s/_transform//\')/.private/id_rsa'" >> /etc/profile
+RUN echo 'export GIT_SSH_COMMAND="ssh -i \$(pwd | sed s/_transform.*//)/.private/id_rsa"' >> /etc/profile
 
 CMD [ "sh", "-c", "wikigdrive --workdir /data server 3000" ]


### PR DESCRIPTION
Need to test this but it's a cool way to use the current directory to set the id for command line git.  This assumes you are not in a subfolder of the repo tho.  maybe in a future pr we could fix it.