### PR TITLE
Update README.md with a simple page to direct you to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-website/docs/_index.md
+# wikiGDrive
+
+[Start Here for documentation](website/docs/_index.md)
+
+Google Drive to MarkDown synchronization
+
+[![Develop Server Deploy](https://github.com/mieweb/wikiGDrive/actions/workflows/DevelopServerDeploy.yml/badge.svg?branch=develop&event=push)](https://github.com/mieweb/wikiGDrive/actions/workflows/DevelopServerDeploy.yml)
+[![Prod Server Deploy](https://github.com/mieweb/wikiGDrive/actions/workflows/ProdServerDeploy.yml/badge.svg?branch=master&event=push)](https://github.com/mieweb/wikiGDrive/actions/workflows/ProdServerDeploy.yml)
+[![CodeQL](https://github.com/mieweb/wikiGDrive/actions/workflows/codeql-analysis.yml/badge.svg?branch=master&event=push)](https://github.com/mieweb/wikiGDrive/actions/workflows/codeql-analysis.yml?query=event%3Apush+branch%3Amaster+)
+
+WikiGDrive is a node app that uses the [Google Drive API](https://developers.google.com/drive/api/v3/quickstart/nodejs) to transform Google Docs and Drawings into markdown.


### PR DESCRIPTION
Making a simple page rather than a redirect since the editing of the readme in wiki drive is confusing.  The simple intro in the readme should just be pointing wikigdrive developers to the documentation folder in the website.