### PR TITLE
Fix pr close action

### DIFF
--- a/.github/workflows/dev-pr-close.yml
+++ b/.github/workflows/dev-pr-close.yml
@@ -12,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_ORG_PAT }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 20
           cache: 'npm'
@@ -33,6 +31,5 @@ jobs:
         run: npm version patch
       - name: Git push version bump
         run: git push origin master --follow-tags --force
-      - id: set-version
-        name: Output version change
+      - name: Output current version
         run: npm pkg get version


### PR DESCRIPTION
@horner see: https://github.com/mieweb/wikiGDrive/blob/fix/pr-close/.github/workflows/dev-pr-close.yml#L21-L22
We need 2 secret values GH_ORG_EMAIL, GH_ORG_NAME for version bump commit author.